### PR TITLE
Adapt mock to current version of the mocked library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 /node_modules
+/bower_components

--- a/angular-socket.io-mock.js
+++ b/angular-socket.io-mock.js
@@ -2,41 +2,40 @@
 var ng = angular.module('btford.socket-io',[])
 ng.provider('socketFactory',function(){
   this.$get = function($rootScope){
+    return function socketFactory () {
+      var obj = {};
+      obj.events = {};
+      obj.emits = {};
 
-    var obj = {}
-    obj.events = {}
-    obj.emits = {}
+      // intercept 'on' calls and capture the callbacks
+      obj.on = function(eventName, callback){
+        if(!this.events[eventName]) this.events[eventName] = [];
+        this.events[eventName].push(callback);
+      };
 
-    // intercept 'on' calls and capture the callbacks
-    obj.on = function(eventName, callback){
-      if(!this.events[eventName]) this.events[eventName] = []
-      this.events[eventName].push(callback)
-    }
+      // intercept 'emit' calls from the client and record them to assert against in the test
+      obj.emit = function(eventName){
+        var args = Array.prototype.slice.call(arguments,1);
 
-    // intercept 'emit' calls from the client and record them to assert against in the test
-    obj.emit = function(eventName){
-      var args = Array.prototype.slice.call(arguments,1)
+        if(!this.emits[eventName])
+          this.emits[eventName] = [];
+        this.emits[eventName].push(args);
+      };
 
-      if(!this.emits[eventName])
-        this.emits[eventName] = []
-      this.emits[eventName].push(args)
-    }
+      //simulate an inbound message to the socket from the server (only called from the test)
+      obj.receive = function(eventName){
+        var args = Array.prototype.slice.call(arguments,1);
 
-    //simulate an inbound message to the socket from the server (only called from the test)
-    obj.receive = function(eventName){
-      var args = Array.prototype.slice.call(arguments,1)
+        if (this.events[eventName]) {
+          angular.forEach(this.events[eventName], function(callback){
+            $rootScope.$apply(function() {
+              callback.apply(this, args)
+            });
+          });
+        };
+      };
 
-      if(this.events[eventName]){
-
-        angular.forEach(this.events[eventName], function(callback){
-          $rootScope.$apply(function() {
-
-            callback.apply(this, args)
-          })
-        })
-      }
-    }
-
-    return obj
-  }
-})
+      return obj;
+    };
+  };
+});

--- a/angular-socket.io-mock.spec.js
+++ b/angular-socket.io-mock.spec.js
@@ -4,12 +4,12 @@
 describe('Angular Socket.io Mock',function(){
   beforeEach(module('btford.socket-io'))
   it('should be able to listen on an event',inject(function(socketFactory){
-    expect(socketFactory.on('test-event',function(){})).not.toBe(false)
+    expect(new socketFactory().on('test-event',function(){})).not.toBe(false)
   }))
   it('should be able to emit an event',inject(function(socketFactory){
-    expect(socketFactory.emit('test-event',{})).not.toBe(false)
+    expect(new socketFactory().emit('test-event',{})).not.toBe(false)
   }))
   it('should be able to receive an event',inject(function(socketFactory){
-    expect(socketFactory.receive('test-event',{})).not.toBe(false)
+    expect(new socketFactory().receive('test-event',{})).not.toBe(false)
   }))
 })


### PR DESCRIPTION
Modification: Return a constructor when calling the Provider, like the current version of the original library that is being mocked.

I did this modification to make it work with the lates version I am using of all the libraries.

Let me know if you would like to handle this in a different way or you would like me to do any modification.

Great and useful mock!
Carlos.