### PR TITLE
Updated .receive to acknowledge any .emit events with a callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ angular.module('app')
 
 ## Changelog
 
+### 1.1.0
+
+* .receive will acknowledge any .emit events with a callback as the last parameter
+
 ### 1.0.0
 * Upgraded to work with latest angular.
 * Use 0.1.0 with older versions of angularjs.

--- a/angular-socket.io-mock.js
+++ b/angular-socket.io-mock.js
@@ -15,7 +15,7 @@ ng.provider('socketFactory',function(){
 
       // intercept 'once' calls and treat them as 'on'
       obj.once = obj.on;
-      
+
       // intercept 'emit' calls from the client and record them to assert against in the test
       obj.emit = function(eventName){
         var args = Array.prototype.slice.call(arguments,1);
@@ -34,6 +34,18 @@ ng.provider('socketFactory',function(){
             $rootScope.$apply(function() {
               callback.apply(this, args)
             });
+          });
+        };
+
+        if (this.emits[eventName]) {
+          angular.forEach(this.emits[eventName], function(emit){
+            var lastIndex = emit.length -1;
+            if('function' === typeof emit[lastIndex] && !emit[lastIndex].acknowledged){
+              $rootScope.$apply(function() {
+                emit[lastIndex].acknowledged = true;
+                emit[lastIndex].apply(this, args);
+              });
+            };
           });
         };
       };

--- a/angular-socket.io-mock.spec.js
+++ b/angular-socket.io-mock.spec.js
@@ -2,17 +2,35 @@
 'use strict';
 
 describe('Angular Socket.io Mock',function(){
+  var socketFactory;
   beforeEach(module('btford.socket-io'))
-  it('should be able to listen on an event',inject(function(socketFactory){
+  beforeEach(inject(function(_socketFactory_){ socketFactory = _socketFactory_ }));
+  it('should be able to listen on an event', function(){
     expect(new socketFactory().on('test-event',function(){})).not.toBe(false)
-  }))
-  it('should be able to listen once event',inject(function(socketFactory){
-    expect(socketFactory.once('test-event',function(){})).not.toBe(false)
-  }))
-  it('should be able to emit an event',inject(function(socketFactory){
+  });
+  it('should be able to listen once event', function(){
+    expect(new socketFactory().once('test-event',function(){})).not.toBe(false)
+  });
+  it('should be able to emit an event', function(){
     expect(new socketFactory().emit('test-event',{})).not.toBe(false)
-  }))
-  it('should be able to receive an event',inject(function(socketFactory){
+  });
+  it('should be able to receive an event', function(){
     expect(new socketFactory().receive('test-event',{})).not.toBe(false)
-  }))
+  });
+  it('should be able to acknowledge an emited event only once',function(done){
+    var socket = new socketFactory();
+    var timesCalled = 0;
+
+    socket.emit('test-event',{}, function(resp){
+      expect(resp).not.toBe(false);
+      expect(++timesCalled).toEqual(1);
+    });
+
+    socket.receive('test-event', {});
+    socket.receive('test-event', {});
+
+    setTimeout(function() { // Wait to see if the event was acknowledged twice
+      done();
+    }, 100);
+  });
 })

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-socket.io-mock",
-  "version": "0.1.1",
+  "version": "1.1.1",
   "dependencies": {
     "angular": "latest",
     "angular-socket-io": "latest"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-socket.io-mock",
   "description": "Drop in Mock replacement for angular-socket-io",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "authors": [
     {
       "name": "Bryan Tong",


### PR DESCRIPTION
The socket.io function .emit can pass a function as the last parameter to allow server acknowledgements (http://socket.io/docs/#sending-and-getting-data-(acknowledgements))

This pull request adds this functionality to the .receive function.  Emit events can only be acknowledged once and a 'acknowledged' flag will set on the callback if it has been called (could be useful for debugging).

Updated semver to 1.1.0 and added unit test.