### PR TITLE
Add entry point for the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "angular-socket.io-mock",
   "description": "Drop in Mock replacement for angular-socket-io",
   "version": "1.2.0",
+  "main": "angular-socket.io-mock.js",
   "authors": [
     {
       "name": "Bryan Tong",


### PR DESCRIPTION
Trying to use this lib with **webpack** module loader fails. It causes an error:

```
Error: Cannot find module "angular-socket.io-mock"
```

This PR introduces a fix in `package.json` that points the entry point for this package